### PR TITLE
Runtime constraints to reward range

### DIFF
--- a/gym_roboy/envs/tests/test_msj_env.py
+++ b/gym_roboy/envs/tests/test_msj_env.py
@@ -37,32 +37,27 @@ def test_msj_env_reset(msj_env):
         assert np.allclose(obs1, obs2)
 
 
-@pytest.mark.skip(reason="Needs to update to current 'new_goal' mechanism")
-def test_msj_env_new_goal_is_different_and_feasible(msj_env):
-    for _ in range(10):
-        old_goal = msj_env._goal_joint_angle
+def test_msj_env_new_goal_is_different_and_feasible(msj_env: MsjEnv):
+    for _ in range(3):
+        old_goal = np.array(msj_env._goal_joint_angle)
         msj_env._set_new_goal()
         assert not np.allclose(old_goal, msj_env._goal_joint_angle)
-        assert all(-msj_env._max_joint_angle <= msj_env._goal_joint_angle)
-        assert all(msj_env._goal_joint_angle <= msj_env._max_joint_angle)
+        assert np.all(-msj_env._JOINT_ANGLE_BOUNDS <= msj_env._goal_joint_angle)
+        assert np.all(msj_env._goal_joint_angle <= msj_env._JOINT_ANGLE_BOUNDS)
 
 
 def test_msj_env_reaching_goal_angle_delivers_maximum_reward(msj_env):
     obs = msj_env.reset()
     current_joint_angle = obs[0:3]
-    print("ok")
     msj_env._set_new_goal(goal_joint_angle=current_joint_angle)
-    print("ok")
     zero_action = np.zeros(len(msj_env.action_space.low))
     _, reward, done, _ = msj_env.step(zero_action)
-    print("ok")
 
     assert done is True
     max_reward = msj_env.reward_range[1]
     assert np.isclose(reward, max_reward)
 
 
-@pytest.mark.skip(reason="Do we still have a lowest possible reward?")
 def test_msj_env_reaching_worst_angle_delivers_lowest_reward(msj_env):
     goal_joint_angle = np.array([np.pi]*3)
     current_joint_angle = -goal_joint_angle

--- a/gym_roboy/envs/tests/test_msj_ros_bridge_proxy.py
+++ b/gym_roboy/envs/tests/test_msj_ros_bridge_proxy.py
@@ -1,3 +1,5 @@
+from itertools import combinations
+
 import numpy as np
 import pytest
 
@@ -41,3 +43,10 @@ def test_msj_ros_bridge_proxy_read_state():
 
     assert np.allclose(initial_robot_state.joint_angle, new_robot_state.joint_angle)
     assert np.allclose(initial_robot_state.joint_vel, new_robot_state.joint_vel)
+
+
+@pytest.mark.integration
+def test_msj_ros_bridge_proxy_get_new_goal_joint_angles_results_are_different():
+    different_joint_angles = [ros_bridge_proxy.get_new_goal_joint_angles() for _ in range(5)]
+    for joint_angle1, joint_angle2 in combinations(different_joint_angles, 2):
+        assert not np.allclose(joint_angle1, joint_angle2)


### PR DESCRIPTION
- Corrected boundaries of observation space
- Reward now only depends on `joint_angles` and not on `joint_vel` as well.
- The reward range is checked at runtime
- Ros Bridge Proxy is delaying get_new_joint_angles() s.t. at least 1 second pass between calls.