### PR TITLE
Feature parallel

### DIFF
--- a/gym_roboy/envs/msj_env.py
+++ b/gym_roboy/envs/msj_env.py
@@ -37,10 +37,8 @@ class MsjEnv(gym.GoalEnv):
     def __init__(self, multi_process: bool = False, process_idx: int = 1, ros_proxy: MsjROSProxy=MsjROSBridgeProxy(),
                  seed: int = None, joint_vel_penalty: bool = False, is_tendon_vel_dependent_on_distance: bool = True):
         self._id = process_idx + 1
-        self._multiProcess = multi_process
-        print("ID: " + str(self._id))
         self.seed(seed)
-        self._ros_proxy = MsjROSBridgeProxy(multi_process=self._multiProcess, idx=self._id)
+        self._ros_proxy = MsjROSBridgeProxy(multi_process=self.multi_process, idx=self._id)
         self._set_new_goal()
         some_state = MsjRobotState(
             joint_angle=self._JOINT_ANGLE_BOUNDS, joint_vel=self._GOAL_JOINT_VEL, is_feasible=True)

--- a/gym_roboy/envs/msj_env.py
+++ b/gym_roboy/envs/msj_env.py
@@ -34,11 +34,10 @@ class MsjEnv(gym.GoalEnv):
     _GOAL_JOINT_VEL = np.zeros(MsjRobotState.DIM_JOINT_ANGLE)
     _PENALTY_FOR_TOUCHING_BOUNDARY = 1
 
-    def __init__(self, multi_process: bool = False, process_idx: int = 1,
+    def __init__(self, ros_proxy: MsjROSProxy,
                  seed: int = None, joint_vel_penalty: bool = False, is_tendon_vel_dependent_on_distance: bool = True):
-        self._id = process_idx + 1
         self.seed(seed)
-        self._ros_proxy = MsjROSBridgeProxy(multi_process=multi_process, idx=self._id)
+        self._ros_proxy = ros_proxy
         self._set_new_goal()
         some_state = MsjRobotState(
             joint_angle=self._JOINT_ANGLE_BOUNDS, joint_vel=self._GOAL_JOINT_VEL, is_feasible=True)

--- a/gym_roboy/envs/msj_env.py
+++ b/gym_roboy/envs/msj_env.py
@@ -34,10 +34,11 @@ class MsjEnv(gym.GoalEnv):
     _GOAL_JOINT_VEL = np.zeros(MsjRobotState.DIM_JOINT_ANGLE)
     _PENALTY_FOR_TOUCHING_BOUNDARY = 1
 
-    def __init__(self, ros_proxy: MsjROSProxy = MsjROSBridgeProxy(),
-                 seed: int = None, joint_vel_penalty: bool = False, is_tendon_vel_dependent_on_distance: bool = True):
+    def __init__(self, process_idx: int = 1, seed: int = None, joint_vel_penalty: bool = False, is_tendon_vel_dependent_on_distance: bool = True):
+        self._id = process_idx + 1
+        print("ID: " + str(self._id))
         self.seed(seed)
-        self._ros_proxy = ros_proxy
+        self._ros_proxy = MsjROSBridgeProxy(idx=self._id)
         self._set_new_goal()
         some_state = MsjRobotState(
             joint_angle=self._JOINT_ANGLE_BOUNDS, joint_vel=self._GOAL_JOINT_VEL, is_feasible=True)

--- a/gym_roboy/envs/msj_env.py
+++ b/gym_roboy/envs/msj_env.py
@@ -38,7 +38,7 @@ class MsjEnv(gym.GoalEnv):
                  seed: int = None, joint_vel_penalty: bool = False, is_tendon_vel_dependent_on_distance: bool = True):
         self._id = process_idx + 1
         self.seed(seed)
-        self._ros_proxy = MsjROSBridgeProxy(multi_process=self.multi_process, idx=self._id)
+        self._ros_proxy = MsjROSBridgeProxy(multi_process=multi_process, idx=self._id)
         self._set_new_goal()
         some_state = MsjRobotState(
             joint_angle=self._JOINT_ANGLE_BOUNDS, joint_vel=self._GOAL_JOINT_VEL, is_feasible=True)

--- a/gym_roboy/envs/msj_env.py
+++ b/gym_roboy/envs/msj_env.py
@@ -34,11 +34,13 @@ class MsjEnv(gym.GoalEnv):
     _GOAL_JOINT_VEL = np.zeros(MsjRobotState.DIM_JOINT_ANGLE)
     _PENALTY_FOR_TOUCHING_BOUNDARY = 1
 
-    def __init__(self, process_idx: int = 1, seed: int = None, joint_vel_penalty: bool = False, is_tendon_vel_dependent_on_distance: bool = True):
+    def __init__(self, multi_process: bool = False, process_idx: int = 1, ros_proxy: MsjROSProxy=MsjROSBridgeProxy(),
+                 seed: int = None, joint_vel_penalty: bool = False, is_tendon_vel_dependent_on_distance: bool = True):
         self._id = process_idx + 1
+        self._multiProcess = multi_process
         print("ID: " + str(self._id))
         self.seed(seed)
-        self._ros_proxy = MsjROSBridgeProxy(idx=self._id)
+        self._ros_proxy = MsjROSBridgeProxy(multi_process=self._multiProcess, idx=self._id)
         self._set_new_goal()
         some_state = MsjRobotState(
             joint_angle=self._JOINT_ANGLE_BOUNDS, joint_vel=self._GOAL_JOINT_VEL, is_feasible=True)

--- a/gym_roboy/envs/msj_env.py
+++ b/gym_roboy/envs/msj_env.py
@@ -34,7 +34,7 @@ class MsjEnv(gym.GoalEnv):
     _GOAL_JOINT_VEL = np.zeros(MsjRobotState.DIM_JOINT_ANGLE)
     _PENALTY_FOR_TOUCHING_BOUNDARY = 1
 
-    def __init__(self, multi_process: bool = False, process_idx: int = 1, ros_proxy: MsjROSProxy=MsjROSBridgeProxy(),
+    def __init__(self, multi_process: bool = False, process_idx: int = 1,
                  seed: int = None, joint_vel_penalty: bool = False, is_tendon_vel_dependent_on_distance: bool = True):
         self._id = process_idx + 1
         self.seed(seed)

--- a/gym_roboy/envs/ros_proxy.py
+++ b/gym_roboy/envs/ros_proxy.py
@@ -58,27 +58,20 @@ class MsjROSBridgeProxy(MsjROSProxy):
 
     _RCLPY_INITIALIZED = False
 
-    def __init__(self, multi_process: bool = False, idx: int = 1, timeout_secs: int = 20):
+    def __init__(self, process_idx: int = 1, timeout_secs: int = 20):
         if not self._RCLPY_INITIALIZED:
             rclpy.init()
             MsjROSBridgeProxy._RCLPY_INITIALIZED = True
         self._timeout_secs = timeout_secs
         self._step_size = 0.1
-        self._id = idx
-        self._multi_process = multi_process
         self.node = rclpy.create_node('gym_rosnode')
-        self._create_ros_client()
+        self._create_ros_client(process_idx)
         self._last_time_gym_goal_service_was_called = datetime.now()
 
-    def _create_ros_client(self):
-        if self._multi_process:
-            self.step_client = self.node.create_client(GymStep, '/instance' + str(self._id) + '/gym_step')
-            self.reset_client = self.node.create_client(GymReset, '/instance' + str(self._id) + '/gym_reset')
-            self.goal_client = self.node.create_client(GymGoal, '/instance' + str(self._id) + '/gym_goal')
-        else:
-            self.step_client = self.node.create_client(GymStep, '/gym_step')
-            self.reset_client = self.node.create_client(GymReset, '/gym_reset')
-            self.goal_client = self.node.create_client(GymGoal, '/gym_goal')
+    def _create_ros_client(self, process_idx: int):
+        self.step_client = self.node.create_client(GymStep, '/instance' + str(process_idx) + '/gym_step')
+        self.reset_client = self.node.create_client(GymReset, '/instance' + str(process_idx) + '/gym_reset')
+        self.goal_client = self.node.create_client(GymGoal, '/instance' + str(process_idx) + '/gym_goal')
 
     def _log_robot_state(self, robot_state):
         q_pos = robot_state.q

--- a/gym_roboy/envs/ros_proxy.py
+++ b/gym_roboy/envs/ros_proxy.py
@@ -58,7 +58,7 @@ class MsjROSBridgeProxy(MsjROSProxy):
 
     _RCLPY_INITIALIZED = False
 
-    def __init__(self, multi_process: bool = False, idx: int = 1, timeout_secs: int = 10):
+    def __init__(self, multi_process: bool = False, idx: int = 1, timeout_secs: int = 2):
         if not self._RCLPY_INITIALIZED:
             rclpy.init()
             MsjROSBridgeProxy._RCLPY_INITIALIZED = True

--- a/gym_roboy/envs/ros_proxy.py
+++ b/gym_roboy/envs/ros_proxy.py
@@ -58,7 +58,7 @@ class MsjROSBridgeProxy(MsjROSProxy):
 
     _RCLPY_INITIALIZED = False
 
-    def __init__(self, multi_process: bool = False, idx: int = 1, timeout_secs: int = 2):
+    def __init__(self, multi_process: bool = False, idx: int = 1, timeout_secs: int = 10):
         if not self._RCLPY_INITIALIZED:
             rclpy.init()
             MsjROSBridgeProxy._RCLPY_INITIALIZED = True
@@ -67,10 +67,10 @@ class MsjROSBridgeProxy(MsjROSProxy):
         self._id = idx
         self._multi_process = multi_process
         self.node = rclpy.create_node('gym_rosnode')
-        self._create_client()
+        self._create_ros_client()
         self._last_time_gym_goal_service_was_called = datetime.now()
 
-    def _create_client(self):
+    def _create_ros_client(self):
         if self._multi_process:
             self.step_client = self.node.create_client(GymStep, '/instance' + str(self._id) + '/gym_step')
             self.reset_client = self.node.create_client(GymReset, '/instance' + str(self._id) + '/gym_reset')

--- a/gym_roboy/envs/ros_proxy.py
+++ b/gym_roboy/envs/ros_proxy.py
@@ -58,7 +58,7 @@ class MsjROSBridgeProxy(MsjROSProxy):
 
     _RCLPY_INITIALIZED = False
 
-    def __init__(self, multi_process: bool = False, idx: int = 1, timeout_secs: int = 2):
+    def __init__(self, multi_process: bool = False, idx: int = 1, timeout_secs: int = 20):
         if not self._RCLPY_INITIALIZED:
             rclpy.init()
             MsjROSBridgeProxy._RCLPY_INITIALIZED = True

--- a/gym_roboy/envs/ros_proxy.py
+++ b/gym_roboy/envs/ros_proxy.py
@@ -58,18 +58,21 @@ class MsjROSBridgeProxy(MsjROSProxy):
 
     _RCLPY_INITIALIZED = False
 
-    def __init__(self, timeout_secs: int = 2):
+    def __init__(self, idx: int = 1, timeout_secs: int = 2):
         if not self._RCLPY_INITIALIZED:
             rclpy.init()
             MsjROSBridgeProxy._RCLPY_INITIALIZED = True
         self._timeout_secs = timeout_secs
         self._step_size = 0.1
-
+        self._id = idx
         self.node = rclpy.create_node('gym_rosnode')
-        self.step_client = self.node.create_client(GymStep, 'gym_step')
-        self.reset_client = self.node.create_client(GymReset, 'gym_reset')
-        self.goal_client = self.node.create_client(GymGoal, 'gym_goal')
+        self._create_client()
         self._last_time_gym_goal_service_was_called = datetime.now()
+
+    def _create_client(self):
+        self.step_client = self.node.create_client(GymStep, '/instance' + str(self._id) + '/gym_step')
+        self.reset_client = self.node.create_client(GymReset, '/instance' + str(self._id) + '/gym_reset')
+        self.goal_client = self.node.create_client(GymGoal, '/instance' + str(self._id) + '/gym_goal')
 
     def _log_robot_state(self, robot_state):
         q_pos = robot_state.q

--- a/gym_roboy/envs/ros_proxy.py
+++ b/gym_roboy/envs/ros_proxy.py
@@ -58,21 +58,27 @@ class MsjROSBridgeProxy(MsjROSProxy):
 
     _RCLPY_INITIALIZED = False
 
-    def __init__(self, idx: int = 1, timeout_secs: int = 2):
+    def __init__(self, multi_process: bool = False, idx: int = 1, timeout_secs: int = 2):
         if not self._RCLPY_INITIALIZED:
             rclpy.init()
             MsjROSBridgeProxy._RCLPY_INITIALIZED = True
         self._timeout_secs = timeout_secs
         self._step_size = 0.1
         self._id = idx
+        self._multi_process = multi_process
         self.node = rclpy.create_node('gym_rosnode')
         self._create_client()
         self._last_time_gym_goal_service_was_called = datetime.now()
 
     def _create_client(self):
-        self.step_client = self.node.create_client(GymStep, '/instance' + str(self._id) + '/gym_step')
-        self.reset_client = self.node.create_client(GymReset, '/instance' + str(self._id) + '/gym_reset')
-        self.goal_client = self.node.create_client(GymGoal, '/instance' + str(self._id) + '/gym_goal')
+        if self._multi_process:
+            self.step_client = self.node.create_client(GymStep, '/instance' + str(self._id) + '/gym_step')
+            self.reset_client = self.node.create_client(GymReset, '/instance' + str(self._id) + '/gym_reset')
+            self.goal_client = self.node.create_client(GymGoal, '/instance' + str(self._id) + '/gym_goal')
+        else:
+            self.step_client = self.node.create_client(GymStep, '/gym_step')
+            self.reset_client = self.node.create_client(GymReset, '/gym_reset')
+            self.goal_client = self.node.create_client(GymGoal, '/gym_goal')
 
     def _log_robot_state(self, robot_state):
         q_pos = robot_state.q

--- a/gym_roboy/parallel_compute.py
+++ b/gym_roboy/parallel_compute.py
@@ -11,6 +11,7 @@ RESULTS_DIR = "./training_results"
 assert not os.path.isdir(RESULTS_DIR), "Folder '{}' already exists".format(RESULTS_DIR)
 MODEL_FILE = "./model.pkl"
 
+
 def setup_constructor(rank, seed=0):
     def our_env_constructor() -> gym.Env:
         environment = MsjEnv(MsjROSBridgeProxy(process_idx= rank))
@@ -18,6 +19,7 @@ def setup_constructor(rank, seed=0):
         return environment
 
     return our_env_constructor
+
 
 num_cpu = int(sys.argv[1])
 env = SubprocVecEnv([setup_constructor(i + 1) for i in range(num_cpu)])

--- a/gym_roboy/parallel_compute.py
+++ b/gym_roboy/parallel_compute.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+import gym
+import gym_roboy
+from stable_baselines.common.vec_env import DummyVecEnv, SubprocVecEnv
+from stable_baselines import PPO2
+
+arg_workers = int(sys.argv[1])
+
+RESULTS_DIR = "./training_results"
+assert not os.path.isdir(RESULTS_DIR), "Folder '{}' already exists".format(RESULTS_DIR)
+MODEL_FILE = "./model.pkl"
+
+def setup_constructor(multi_process, rank, seed=0):
+
+    def our_env_constructor() -> gym.Env:
+        environment = gym.make("msj-control-v0", multi_process = multi_process, process_idx = rank)
+        environment.seed(seed + rank)
+        return environment
+
+    return our_env_constructor
+
+
+num_cpu = arg_workers
+multi_process = bool(num_cpu > 1)
+env = SubprocVecEnv([setup_constructor(multi_process, i) for i in range(num_cpu)])
+agent = PPO2("MlpPolicy", env, tensorboard_log=RESULTS_DIR)
+
+while True:
+    agent.learn(total_timesteps=1000000)
+    agent.save(MODEL_FILE)
+
+

--- a/gym_roboy/parallel_compute.py
+++ b/gym_roboy/parallel_compute.py
@@ -3,27 +3,24 @@ import sys
 
 import gym
 import gym_roboy
-from stable_baselines.common.vec_env import DummyVecEnv, SubprocVecEnv
+from stable_baselines.common.vec_env import SubprocVecEnv
 from stable_baselines import PPO2
-
-
+from .envs import MsjEnv, MsjROSBridgeProxy
 
 RESULTS_DIR = "./training_results"
 assert not os.path.isdir(RESULTS_DIR), "Folder '{}' already exists".format(RESULTS_DIR)
 MODEL_FILE = "./model.pkl"
 
-def setup_constructor(multi_process, rank, seed=0):
-
+def setup_constructor(rank, seed=0):
     def our_env_constructor() -> gym.Env:
-        environment = gym.make("msj-control-v0", multi_process = multi_process, process_idx = rank)
+        environment = MsjEnv(MsjROSBridgeProxy(process_idx= rank))
         environment.seed(seed + rank)
         return environment
 
     return our_env_constructor
 
 num_cpu = int(sys.argv[1])
-multi_process = bool(num_cpu > 1)
-env = SubprocVecEnv([setup_constructor(multi_process, i) for i in range(num_cpu)])
+env = SubprocVecEnv([setup_constructor(i + 1) for i in range(num_cpu)])
 agent = PPO2("MlpPolicy", env, tensorboard_log=RESULTS_DIR)
 
 while True:

--- a/gym_roboy/parallel_compute.py
+++ b/gym_roboy/parallel_compute.py
@@ -6,7 +6,7 @@ import gym_roboy
 from stable_baselines.common.vec_env import DummyVecEnv, SubprocVecEnv
 from stable_baselines import PPO2
 
-arg_workers = int(sys.argv[1])
+
 
 RESULTS_DIR = "./training_results"
 assert not os.path.isdir(RESULTS_DIR), "Folder '{}' already exists".format(RESULTS_DIR)
@@ -21,8 +21,7 @@ def setup_constructor(multi_process, rank, seed=0):
 
     return our_env_constructor
 
-
-num_cpu = arg_workers
+num_cpu = int(sys.argv[1])
 multi_process = bool(num_cpu > 1)
 env = SubprocVecEnv([setup_constructor(multi_process, i) for i in range(num_cpu)])
 agent = PPO2("MlpPolicy", env, tensorboard_log=RESULTS_DIR)


### PR DESCRIPTION
- Adapting the gym-roboy environment to parallel training.
- Using the SubprocVecenv to create parallel instances of the environment.
- Inject the distinct id to a specific environment instance by gym.make('msj-control-v0', process_idx = rank) in parallel_compute.py
- Number of workers can be transferred as an argument to bridge_scripts ./launch_everything_parallel.sh num_workers
- One process cases also taken into consideration.  It should run normally as before.