### PR TITLE
Rename ROSProxy to SimulationClient

### DIFF
--- a/gym_roboy/envs/__init__.py
+++ b/gym_roboy/envs/__init__.py
@@ -1,2 +1,2 @@
-from .ros_proxy import ROSProxy, ROSBridgeProxy, StubROSProxy
+from .simulation_client import RosSimulationClient, RosSimulationClient, StubSimulationClient
 from .roboy_env import RoboyEnv

--- a/gym_roboy/envs/__init__.py
+++ b/gym_roboy/envs/__init__.py
@@ -1,2 +1,2 @@
-from .simulation_client import RosSimulationClient, RosSimulationClient, StubSimulationClient
+from .simulation_client import SimulationClient, RosSimulationClient, StubSimulationClient
 from .roboy_env import RoboyEnv

--- a/gym_roboy/envs/roboy_env.py
+++ b/gym_roboy/envs/roboy_env.py
@@ -2,7 +2,7 @@ from typing import Tuple
 import numpy as np
 import gym
 from gym import spaces
-from . import ROSProxy
+from . import RosSimulationClient
 from .robots import RobotState, RoboyRobot
 
 
@@ -14,7 +14,7 @@ def _l2_distance(joint_angle1, joint_angle2):
 
 class RoboyEnv(gym.GoalEnv):
 
-    def __init__(self, ros_proxy: ROSProxy, seed: int = None,
+    def __init__(self, ros_proxy: RosSimulationClient, seed: int = None,
                  joint_vel_penalty: bool = False,
                  is_tendon_vel_dependent_on_distance: bool = True,
                  is_agent_getting_bonus_for_reaching_goal: bool = True):

--- a/gym_roboy/envs/simulation_client.py
+++ b/gym_roboy/envs/simulation_client.py
@@ -11,7 +11,7 @@ from typeguard import typechecked
 from .robots import RobotState, RoboyRobot
 
 
-class ROSProxy:
+class SimulationClient:
     """
     This interface defines how the RoboyEnv interacts with the Roboy Robot.
     One implementation will use the ROS1 service over ROS2 bridge.
@@ -31,8 +31,8 @@ class ROSProxy:
         raise NotImplementedError
 
 
-class StubROSProxy(ROSProxy):
-    """This implementation is a mock for unit testing purposes."""
+class StubSimulationClient(SimulationClient):
+    """This implementation is a stub for unit testing purposes."""
 
     def __init__(self, robot: RoboyRobot):
         self.robot = robot
@@ -55,14 +55,14 @@ class StubROSProxy(ROSProxy):
         return self.robot.new_random_state().joint_angles
 
 
-class ROSBridgeProxy(ROSProxy):
+class RosSimulationClient(SimulationClient):
 
     _RCLPY_INITIALIZED = False
 
     def __init__(self, robot: RoboyRobot, process_idx: int = 1, timeout_secs: int = 2):
         if not self._RCLPY_INITIALIZED:
             rclpy.init()
-            ROSBridgeProxy._RCLPY_INITIALIZED = True
+            RosSimulationClient._RCLPY_INITIALIZED = True
         self.robot = robot
         self._timeout_secs = timeout_secs
         self._step_size = 0.1

--- a/gym_roboy/envs/tests/test_roboy_env.py
+++ b/gym_roboy/envs/tests/test_roboy_env.py
@@ -2,16 +2,16 @@ from typing import Sequence
 import numpy as np
 from itertools import combinations
 import pytest
-from .. import RoboyEnv, StubROSProxy, ROSBridgeProxy
+from .. import RoboyEnv, StubSimulationClient, RosSimulationClient
 from ..robots import RobotState, MsjRobot
 
 
 MSJ_ROBOT = MsjRobot()
-MOCK_ROS_PROXY = StubROSProxy(robot=MSJ_ROBOT)
+MOCK_ROS_PROXY = StubSimulationClient(robot=MSJ_ROBOT)
 MOCK_ROBOY_ENV = RoboyEnv(ros_proxy=MOCK_ROS_PROXY)
 constructors = [
     lambda: MOCK_ROBOY_ENV,
-    pytest.param(lambda: RoboyEnv(ros_proxy=ROSBridgeProxy(robot=MSJ_ROBOT)), marks=pytest.mark.integration)
+    pytest.param(lambda: RoboyEnv(ros_proxy=RosSimulationClient(robot=MSJ_ROBOT)), marks=pytest.mark.integration)
 ]
 
 
@@ -78,12 +78,12 @@ def test_roboy_env_reaching_goal_joint_angle_but_moving_returns_done_equals_fals
 
 
 def test_roboy_env_joint_vel_penalty_affects_worst_possible_reward():
-    env = RoboyEnv(ros_proxy=StubROSProxy(robot=MSJ_ROBOT), joint_vel_penalty=False)
+    env = RoboyEnv(ros_proxy=StubSimulationClient(robot=MSJ_ROBOT), joint_vel_penalty=False)
     largest_distance = np.linalg.norm(2 * np.ones(MSJ_ROBOT.get_joint_angles_space().shape))
     worst_possible_reward_from_angles = -np.exp(largest_distance) - abs(env._PENALTY_FOR_TOUCHING_BOUNDARY)
     assert np.isclose(env.reward_range[0], worst_possible_reward_from_angles)
 
-    env = RoboyEnv(ros_proxy=StubROSProxy(robot=MSJ_ROBOT), joint_vel_penalty=True)
+    env = RoboyEnv(ros_proxy=StubSimulationClient(robot=MSJ_ROBOT), joint_vel_penalty=True)
     assert env.reward_range[0] < worst_possible_reward_from_angles
 
 

--- a/gym_roboy/envs/tests/test_simulation_client.py
+++ b/gym_roboy/envs/tests/test_simulation_client.py
@@ -7,14 +7,14 @@ import pytest
 from .. import RosSimulationClient
 from ..robots import MsjRobot
 
-simulation_client = RosSimulationClient(robot=MsjRobot())
+SIMULATION_CLIENT = RosSimulationClient(robot=MsjRobot())
 
 
 @pytest.mark.integration
 def test_simulation_client_reset():
     """reset function sets all joint angles to zero in simulation"""
 
-    new_robot_state = simulation_client.forward_reset_command()
+    new_robot_state = SIMULATION_CLIENT.forward_reset_command()
     assert np.allclose([0, 0, 0], new_robot_state.joint_angles)
     assert np.allclose([0, 0, 0], new_robot_state.joint_vels)
 
@@ -24,9 +24,9 @@ def test_simulation_client_step():
     """calling the step function changes the robot state"""
 
     random_action = [0.01, 0.01, 0.01, 0.015, 0.01, 0.02, 0.02, 0.02]
-    initial_robot_state = simulation_client.forward_step_command(random_action)
+    initial_robot_state = SIMULATION_CLIENT.forward_step_command(random_action)
 
-    new_robot_state = simulation_client.forward_step_command(random_action)
+    new_robot_state = SIMULATION_CLIENT.forward_step_command(random_action)
 
     for x, y in zip(initial_robot_state.joint_angles, new_robot_state.joint_angles):
         assert np.abs(x - y) > 0.00001
@@ -39,8 +39,8 @@ def test_simulation_client_step():
 def test_simulation_client_read_state():
     """calling the read state function doesn't change the robot state"""
 
-    initial_robot_state = simulation_client.read_state()
-    new_robot_state = simulation_client.read_state()
+    initial_robot_state = SIMULATION_CLIENT.read_state()
+    new_robot_state = SIMULATION_CLIENT.read_state()
 
     assert np.allclose(initial_robot_state.joint_angles, new_robot_state.joint_angles)
     assert np.allclose(initial_robot_state.joint_vels, new_robot_state.joint_vels)
@@ -48,7 +48,7 @@ def test_simulation_client_read_state():
 
 @pytest.mark.integration
 def test_simulation_client_get_new_goal_joint_angles_results_are_different():
-    different_joint_angles = [simulation_client.get_new_goal_joint_angles() for _ in range(5)]
+    different_joint_angles = [SIMULATION_CLIENT.get_new_goal_joint_angles() for _ in range(5)]
     for joint_angle1, joint_angle2 in combinations(different_joint_angles, 2):
         assert not np.allclose(joint_angle1, joint_angle2)
 
@@ -58,22 +58,22 @@ def test_simulation_client_stepping_on_the_boundary_does_not_reset():
     random.seed(0)
     actions = MsjRobot.get_action_space()
     strong_action = [float(random.choice(i)) for i in zip(actions.high, actions.low)]
-    simulation_client.forward_reset_command = lambda: pytest.fail("should not call this")
+    SIMULATION_CLIENT.forward_reset_command = lambda: pytest.fail("should not call this")
 
     for _ in range(1000):
-        robot_state = simulation_client.forward_step_command(action=strong_action)
+        robot_state = SIMULATION_CLIENT.forward_step_command(action=strong_action)
         if not robot_state.is_feasible:
             break
 
     assert not robot_state.is_feasible
-    robot_state = simulation_client.forward_step_command(action=strong_action)
+    robot_state = SIMULATION_CLIENT.forward_step_command(action=strong_action)
     assert not robot_state.is_feasible
 
 
 @pytest.mark.integration
 def test_simulation_client_load_test():
-    p = RosSimulationClient(robot=MsjRobot())
+    sim_client = RosSimulationClient(robot=MsjRobot())
     for idx in range(100):
-        p.forward_reset_command()
-        p.get_new_goal_joint_angles()
+        sim_client.forward_reset_command()
+        sim_client.get_new_goal_joint_angles()
         print("completed" + str(idx))

--- a/gym_roboy/train_parallel.py
+++ b/gym_roboy/train_parallel.py
@@ -4,7 +4,7 @@ import sys
 import gym
 from stable_baselines.common.vec_env import SubprocVecEnv
 from stable_baselines import PPO2
-from .envs import RoboyEnv, ROSBridgeProxy
+from .envs import RoboyEnv, RosSimulationClient
 from .envs.robots import MsjRobot
 
 
@@ -17,7 +17,7 @@ TRAINING_STEPS_BETWEEN_BACKUPS = 1000000
 
 def setup_constructor(rank, seed=0):
     def our_env_constructor() -> gym.Env:
-        environment = RoboyEnv(ROSBridgeProxy(process_idx= rank, robot=MsjRobot()))
+        environment = RoboyEnv(RosSimulationClient(process_idx= rank, robot=MsjRobot()))
         environment.seed(seed + rank)
         return environment
 

--- a/gym_roboy/visualize_agent.py
+++ b/gym_roboy/visualize_agent.py
@@ -10,7 +10,7 @@ assert os.path.isfile(MODEL_FILE), "File not found: '{}'".format(MODEL_FILE)
 from stable_baselines.common.vec_env import DummyVecEnv
 from stable_baselines import PPO2
 
-from .envs import RoboyEnv, ROSBridgeProxy
+from .envs import RoboyEnv, RosSimulationClient
 from .envs.robots import MsjRobot
 
 
@@ -27,7 +27,7 @@ class Logger:
 def main():
     logger = Logger()
     # The algorithms require a vectorized environment to run
-    env_constructor = lambda: RoboyEnv(ros_proxy=ROSBridgeProxy(robot=MsjRobot()))
+    env_constructor = lambda: RoboyEnv(ros_proxy=RosSimulationClient(robot=MsjRobot()))
     env = DummyVecEnv([env_constructor])
 
     agent = PPO2.load(MODEL_FILE)

--- a/gym_roboy/visualize_agent.py
+++ b/gym_roboy/visualize_agent.py
@@ -27,7 +27,7 @@ class Logger:
 def main():
     logger = Logger()
     # The algorithms require a vectorized environment to run
-    env_constructor = lambda: RoboyEnv(ros_proxy=RosSimulationClient(robot=MsjRobot()))
+    env_constructor = lambda: RoboyEnv(simulation_client=RosSimulationClient(robot=MsjRobot()))
     env = DummyVecEnv([env_constructor])
 
     agent = PPO2.load(MODEL_FILE)


### PR DESCRIPTION
* `ROSProxy` is an interface definition to step and reset the simulation that should be independent of ROS
* `SimulationClient` seems like a more descriptive name for it. (feel free if you have another suggestion)
* `RosSimulationClient` is a type of `SimulationClient` that implements the communication with `rclpy`.