### PR TITLE
Remove constraint on tendon_vels

### DIFF
--- a/gym_roboy/envs/roboy_env.py
+++ b/gym_roboy/envs/roboy_env.py
@@ -63,13 +63,13 @@ class RoboyEnv(gym.GoalEnv):
         info = {}
         reward = self.compute_reward(current_state=new_state, goal_state=self._goal_state, info=info)
         done = self._did_reach_goal(current_state=new_state, goal_state=self._goal_state) or \
-               self._ran_out_of_time()
+               self._reached_max_steps()
         if done:
             self._set_new_goal()
 
         return obs, reward, done, info
 
-    def _ran_out_of_time(self) -> bool:
+    def _reached_max_steps(self) -> bool:
         return self.step_num > self._MAX_EPISODE_LENGTH
 
     def _make_obs(self, robot_state: RobotState):
@@ -142,7 +142,16 @@ def _l2_distance(joint_angle1, joint_angle2):
 
 @typechecked
 def _rescale_from_one_space_to_other(
-        input_space: spaces.Box, output_space: spaces.Box, input_val: np.ndarray) -> np.ndarray:
+        input_val: np.ndarray, input_space: spaces.Box, output_space: spaces.Box) -> np.ndarray:
+    """
+    Transforms a point in a input space to a corresponding point in the
+    output space. The output point is as far away from the output
+    boundaries as the input point is from the input boundaries.
+    :param input_space: bounded Box
+    :param output_space: bounded Box
+    :param input_val: The input point
+    :return: The output point in the output space
+    """
     assert input_space.shape == output_space.shape
     assert input_space.contains(input_val)
     slope = (output_space.high-output_space.low) / (input_space.high-input_space.low)

--- a/gym_roboy/envs/tests/test_roboy_env.py
+++ b/gym_roboy/envs/tests/test_roboy_env.py
@@ -2,9 +2,10 @@ from typing import Sequence
 import numpy as np
 from itertools import combinations
 import pytest
-from .. import RoboyEnv
+from gym import spaces
 from ..simulations import StubSimulationClient, RosSimulationClient
 from ..robots import RobotState, MsjRobot
+from ..roboy_env import RoboyEnv, _rescale_from_one_space_to_other
 
 
 MSJ_ROBOT = MsjRobot()
@@ -189,3 +190,24 @@ def test_roboy_reset_sets_step_number_to_one():
 
 def _strictly_increasing(sequence: Sequence[float]):
     return all(x < y for x, y in zip(sequence, sequence[1:]))
+
+
+def test_roboy_env_rescale_from_one_space_to_other():
+    np.random.seed(0)
+    input_space = _create_random_space()
+    output_space = _create_random_space()
+
+    expected_output_space_high = _rescale_from_one_space_to_other(
+        input_space=input_space, output_space=output_space, input_val=input_space.high)
+    print(input_space.high, input_space.low)
+    assert np.allclose(expected_output_space_high, output_space.high)
+
+    expected_output_space_low = _rescale_from_one_space_to_other(
+        input_space=input_space, output_space=output_space, input_val=input_space.low)
+    assert np.allclose(expected_output_space_low, output_space.low)
+
+
+def _create_random_space() -> spaces.Box:
+    dim = MOCK_ROBOY_ENV.action_space.shape[0]
+    return spaces.Box(low=-np.random.uniform(size=dim),
+                      high=np.random.uniform(size=dim), dtype="float32")

--- a/gym_roboy/envs/tests/test_roboy_env.py
+++ b/gym_roboy/envs/tests/test_roboy_env.py
@@ -75,8 +75,8 @@ def test_roboy_env_reaching_goal_joint_angle_but_moving_returns_done_equals_fals
 
     roboy_env._last_state.joint_vels = MSJ_ROBOT.get_joint_vels_space().high
 
-    assert not roboy_env._did_complete_successfully(current_state=roboy_env._last_state,
-                                                  goal_state=roboy_env._goal_state)
+    assert not roboy_env._did_reach_goal(current_state=roboy_env._last_state,
+                                         goal_state=roboy_env._goal_state)
 
 
 def test_roboy_env_joint_vel_penalty_affects_worst_possible_reward():
@@ -175,7 +175,7 @@ def test_roboy_env_maximum_episode_length():
     _, _, done, _ = env.step(np.zeros(env.action_space.shape))
     assert not done
 
-    assert not env._did_complete_successfully(env._last_state, env._goal_state)
+    assert not env._did_reach_goal(env._last_state, env._goal_state)
     _, _, done, _ = env.step(env.action_space.sample())
     assert done
 


### PR DESCRIPTION
* As discussed in Telegram, scaling down tendon_vels (actions) may cause the agent to be unable to stay close to the goal.
* Removed action `scaling_factor` and replaced it with a rescaling like we had before, but that requires no symmetric normalization.